### PR TITLE
Fix SaaS admin queries and clean plan management

### DIFF
--- a/client/src/components/PlanCard.tsx
+++ b/client/src/components/PlanCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
@@ -24,12 +24,12 @@ type Plan = {
 type EditablePlan = {
   id: string;
   name: string;
-  description?: string | null;
-  price: string | number;
-  isActive?: boolean | null;
-  maxUsers?: number | string | null;
-  maxTransactionsPerMonth?: number | string | null;
-  maxStorageGB?: number | string | null;
+  description: string;
+  price: string;
+  isActive: boolean;
+  maxUsers: string;
+  maxTransactionsPerMonth: string;
+  maxStorageGB: string;
   currency?: string | null;
 };
 
@@ -58,15 +58,40 @@ const formatCurrency = (amount: number | null | undefined, currency = 'IDR') => 
   }).format(amount);
 };
 
-const coerceOptionalNumber = (value: unknown) => {
-  if (value === undefined || value === null || value === '') {
+const createEditablePlan = (plan: Plan): EditablePlan => ({
+  id: plan.id,
+  name: plan.name,
+  description: plan.description ?? '',
+  price: plan.price != null ? String(plan.price) : '',
+  isActive: plan.isActive ?? true,
+  maxUsers: plan.maxUsers != null ? String(plan.maxUsers) : '',
+  maxTransactionsPerMonth:
+    plan.maxTransactionsPerMonth != null ? String(plan.maxTransactionsPerMonth) : '',
+  maxStorageGB: plan.maxStorageGB != null ? String(plan.maxStorageGB) : '',
+  currency: plan.currency ?? 'IDR',
+});
+
+const parseRequiredPositiveNumber = (value: string, fieldLabel: string) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`${fieldLabel} harus lebih dari 0.`);
+  }
+
+  return Math.round(numeric);
+};
+
+const parseOptionalInteger = (value: string, fieldLabel: string, options: { min?: number } = {}) => {
+  if (!value) {
     return undefined;
   }
 
-  const numeric = typeof value === 'number' ? value : Number(value);
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+    throw new Error(`${fieldLabel} harus berupa angka bulat.`);
+  }
 
-  if (Number.isNaN(numeric)) {
-    throw new Error('Nilai numerik tidak valid.');
+  if (options.min !== undefined && numeric < options.min) {
+    throw new Error(`${fieldLabel} minimal ${options.min}.`);
   }
 
   return numeric;
@@ -76,122 +101,84 @@ export default function PlanCard({ plan, onUpdate }: PlanCardProps) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [editPlan, setEditPlan] = useState<EditablePlan | null>(null);
+  const [editPlan, setEditPlan] = useState<EditablePlan>(() => createEditablePlan(plan));
+
+  useEffect(() => {
+    if (!isDialogOpen) {
+      setEditPlan(createEditablePlan(plan));
+    }
+  }, [plan, isDialogOpen]);
 
   const updatePlanMutation = useMutation({
-
-    mutationFn: async (data: any) => apiRequest('PUT', `/api/admin/saas/plans/${data.id}`, data),
-
     mutationFn: async (data: EditablePlan) => {
-      if (!data.id) {
-        throw new Error('Plan tidak ditemukan.');
+      const trimmedName = data.name.trim();
+      if (!trimmedName) {
+        throw new Error('Nama paket harus diisi.');
       }
 
-      const payload: Record<string, unknown> = {};
+      const payload: Record<string, unknown> = {
+        name: trimmedName,
+        description: data.description.trim(),
+        price: parseRequiredPositiveNumber(data.price, 'Harga paket'),
+        isActive: Boolean(data.isActive),
+        currency: data.currency ?? 'IDR',
+      };
 
-      if (data.name !== undefined) {
-        const trimmedName = data.name.trim();
-        if (!trimmedName) {
-          throw new Error('Nama paket harus diisi.');
-        }
-        payload.name = trimmedName;
+      const maxUsers = parseOptionalInteger(data.maxUsers, 'Jumlah pengguna maksimal', { min: 1 });
+      if (maxUsers !== undefined) {
+        payload.maxUsers = maxUsers;
       }
 
-      if (data.description !== undefined) {
-        payload.description = data.description?.trim() ?? '';
+      const maxTransactions = parseOptionalInteger(
+        data.maxTransactionsPerMonth,
+        'Transaksi maksimal per bulan',
+        { min: 0 },
+      );
+      if (maxTransactions !== undefined) {
+        payload.maxTransactionsPerMonth = maxTransactions;
       }
 
-      if (data.price !== undefined) {
-        const numericPrice = coerceOptionalNumber(data.price);
-        if (numericPrice === undefined || numericPrice <= 0) {
-          throw new Error('Harga paket harus lebih dari 0.');
-        }
-        payload.price = numericPrice;
+      const maxStorage = parseOptionalInteger(data.maxStorageGB, 'Kapasitas penyimpanan (GB)', { min: 0 });
+      if (maxStorage !== undefined) {
+        payload.maxStorageGB = maxStorage;
       }
 
-      if (data.maxUsers !== undefined) {
-        const maxUsers = coerceOptionalNumber(data.maxUsers);
-        if (maxUsers !== undefined) {
-          if (!Number.isInteger(maxUsers) || maxUsers < 1) {
-            throw new Error('Jumlah pengguna maksimal harus minimal 1.');
-          }
-          payload.maxUsers = maxUsers;
-        }
-      }
-
-      if (data.isActive !== undefined && data.isActive !== null) {
-        payload.isActive = data.isActive;
-      }
-
-      if (Object.keys(payload).length === 0) {
-        throw new Error('Tidak ada perubahan yang disimpan.');
-      }
-
-      return apiRequest('PUT', `/api/admin/plans/${data.id}`, payload);
+      return apiRequest('PUT', `/api/admin/saas/plans/${data.id}`, payload);
     },
-
     onSuccess: () => {
-      toast({ title: 'Success', description: 'Plan updated' });
-      setIsDialogOpen(false);
-      setEditPlan(null);
+      toast({ title: 'Success', description: 'Plan updated successfully' });
       queryClient.invalidateQueries({ queryKey: ['/api/admin/saas/plans'] });
+      setIsDialogOpen(false);
+      setEditPlan(createEditablePlan(plan));
       onUpdate?.();
     },
     onError: (error: any) => {
-      toast({ title: 'Error', description: error.message || 'Failed to update plan', variant: 'destructive' });
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to update plan',
+        variant: 'destructive',
+      });
     },
   });
 
-  const openDialog = () => {
-    setEditPlan({
-      id: plan.id,
-      name: plan.name,
-      description: plan.description ?? '',
-      price: plan.price != null ? String(plan.price) : '',
-      isActive: plan.isActive ?? true,
-      maxUsers: plan.maxUsers ?? undefined,
-      maxTransactionsPerMonth: plan.maxTransactionsPerMonth ?? undefined,
-      maxStorageGB: plan.maxStorageGB ?? undefined,
-      currency: plan.currency,
-    });
-    setIsDialogOpen(true);
-  };
-
   const handleDialogChange = (open: boolean) => {
     setIsDialogOpen(open);
-    if (!open) {
-      setEditPlan(null);
+    if (open) {
+      setEditPlan(createEditablePlan(plan));
     }
   };
 
   const handleSave = () => {
-    if (!editPlan) {
-      return;
-    }
     updatePlanMutation.mutate(editPlan);
   };
 
   return (
     <Card className="mb-3 border-l-4 border-l-blue-500">
-      <CardHeader className="flex justify-between items-center">
-
-        <CardTitle>{plan.name}</CardTitle>
-        <Dialog
-          open={editPlan?.id === plan.id}
-          onOpenChange={(open) => {
-            if (open) {
-              setEditPlan({ ...plan });
-            } else {
-              setEditPlan(null);
-            }
-          }}
-        >
-
+      <CardHeader className="flex items-center justify-between">
         <CardTitle>{getPlanLabel(plan.name)}</CardTitle>
         <Dialog open={isDialogOpen} onOpenChange={handleDialogChange}>
-
           <DialogTrigger asChild>
-            <Button size="sm" variant="outline" onClick={openDialog}>
+            <Button size="sm" variant="outline">
               <Pencil className="h-4 w-4" />
             </Button>
           </DialogTrigger>
@@ -199,36 +186,65 @@ export default function PlanCard({ plan, onUpdate }: PlanCardProps) {
             <DialogHeader>
               <DialogTitle>Edit Plan</DialogTitle>
             </DialogHeader>
-            <div className="space-y-2">
+            <div className="space-y-3">
               <Input
                 placeholder="Plan Name"
-                value={editPlan?.name || ''}
-                onChange={(e) => setEditPlan({ ...editPlan!, name: e.target.value })}
+                value={editPlan.name}
+                onChange={(e) => setEditPlan({ ...editPlan, name: e.target.value })}
               />
               <Input
                 placeholder="Description"
-                value={editPlan?.description || ''}
-                onChange={(e) => setEditPlan({ ...editPlan!, description: e.target.value })}
+                value={editPlan.description}
+                onChange={(e) => setEditPlan({ ...editPlan, description: e.target.value })}
               />
               <Input
                 type="number"
-                placeholder="Price"
-                value={editPlan?.price !== undefined ? String(editPlan.price ?? '') : ''}
-                onChange={(e) => setEditPlan({ ...editPlan!, price: e.target.value })}
                 min={1}
+                placeholder="Price"
+                value={editPlan.price}
+                onChange={(e) => setEditPlan({ ...editPlan, price: e.target.value })}
+              />
+              <Input
+                type="number"
+                min={1}
+                placeholder="Maksimal Pengguna"
+                value={editPlan.maxUsers}
+                onChange={(e) => setEditPlan({ ...editPlan, maxUsers: e.target.value })}
+              />
+              <Input
+                type="number"
+                min={0}
+                placeholder="Transaksi / Bulan"
+                value={editPlan.maxTransactionsPerMonth}
+                onChange={(e) =>
+                  setEditPlan({ ...editPlan, maxTransactionsPerMonth: e.target.value })
+                }
+              />
+              <Input
+                type="number"
+                min={0}
+                placeholder="Penyimpanan (GB)"
+                value={editPlan.maxStorageGB}
+                onChange={(e) => setEditPlan({ ...editPlan, maxStorageGB: e.target.value })}
               />
               <div className="flex items-center space-x-2">
                 <Switch
-                  checked={!!editPlan?.isActive}
-                  onCheckedChange={(checked) => setEditPlan({ ...editPlan!, isActive: checked })}
+                  checked={editPlan.isActive}
+                  onCheckedChange={(checked) => setEditPlan({ ...editPlan, isActive: checked })}
                 />
-                <span>{editPlan?.isActive ? 'Active' : 'Inactive'}</span>
+                <span>{editPlan.isActive ? 'Active' : 'Inactive'}</span>
               </div>
               <div className="flex space-x-2">
                 <Button onClick={handleSave} disabled={updatePlanMutation.isPending}>
                   {updatePlanMutation.isPending ? 'Saving...' : 'Save'}
                 </Button>
-                <Button variant="outline" onClick={() => handleDialogChange(false)}>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setIsDialogOpen(false);
+                    setEditPlan(createEditablePlan(plan));
+                  }}
+                >
                   Cancel
                 </Button>
               </div>
@@ -249,15 +265,15 @@ export default function PlanCard({ plan, onUpdate }: PlanCardProps) {
               <span className="font-medium">{plan.maxUsers}</span>
             </div>
           )}
-          <div className="flex justify-between items-center pt-2 border-t">
+          <div className="flex justify-between items-center border-t pt-2">
             <span className="text-muted-foreground">Status</span>
             {plan.isActive ? (
-              <span className="flex items-center space-x-1 text-green-600 font-medium">
+              <span className="flex items-center space-x-1 font-medium text-green-600">
                 <CheckCircle className="h-4 w-4" />
                 <span>Aktif</span>
               </span>
             ) : (
-              <span className="flex items-center space-x-1 text-red-500 font-medium">
+              <span className="flex items-center space-x-1 font-medium text-red-500">
                 <XCircle className="h-4 w-4" />
                 <span>Nonaktif</span>
               </span>

--- a/server/routes/stripe-integration.ts
+++ b/server/routes/stripe-integration.ts
@@ -197,13 +197,8 @@ router.post('/payments/confirm/:paymentId', async (req, res) => {
           .values({
             clientId: client.id,
             planId: plan.id,
-
             planName: planDisplayName,
-            plan: planSlug,
-
-            planName: plan.name,
             plan: subscriptionPlan,
-
             amount: payment.amount.toString(),
             paymentStatus: 'paid',
             startDate: new Date(),
@@ -238,15 +233,7 @@ router.post('/payments/confirm/:paymentId', async (req, res) => {
           .update(clients)
           .set({
             status: 'active',
-
-            settings: sql`jsonb_set(
-              jsonb_set(settings::jsonb, '{planName}', '"${planDisplayName}"'),
-              '{planSlug}',
-              '"${planSlug}"'
-            )`,
-
             settings: JSON.stringify(updatedSettings),
-
             updatedAt: new Date()
           })
           .where(eq(clients.id, client.id));

--- a/shared/saas-utils.ts
+++ b/shared/saas-utils.ts
@@ -1,6 +1,6 @@
-import { subscriptionPlanEnum } from './saas-schema';
+import { PLAN_CODE_VALUES } from './saas-schema';
 
-type SubscriptionPlanSlug = (typeof subscriptionPlanEnum.enumValues)[number];
+type SubscriptionPlanSlug = (typeof PLAN_CODE_VALUES)[number];
 
 const PLAN_NAME_MAP: Record<string, SubscriptionPlanSlug> = {
   basic: 'basic',
@@ -34,7 +34,7 @@ function mapToPlanSlug(planName: string | null | undefined): SubscriptionPlanSlu
     }
   }
 
-  if ((subscriptionPlanEnum.enumValues as readonly string[]).includes(normalizedName as SubscriptionPlanSlug)) {
+  if ((PLAN_CODE_VALUES as readonly string[]).includes(normalizedName as SubscriptionPlanSlug)) {
     return normalizedName as SubscriptionPlanSlug;
   }
 


### PR DESCRIPTION
## Summary
- fix the SaaS admin dashboard queries and plan creation validation
- refactor the plan card editing dialog with stronger validation and state handling
- deduplicate SaaS server routes and stripe integration logic while updating shared plan utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc1178130c8326a8b1bf4a31300f36