### PR TITLE
Allow client setup without super admin

### DIFF
--- a/server/middleware/tenant.ts
+++ b/server/middleware/tenant.ts
@@ -114,15 +114,14 @@ export const tenantMiddleware = async (req: Request, res: Response, next: NextFu
       '/api/whatsapp'
     ];
     
-    // Setup routes are only for super admins - require proper tenant detection
-    const superAdminOnlyRoutes = ['/api/setup', '/api/admin'];
-    
+    // Admin routes remain super-admin only, but allow setup routes for tenant onboarding
+    const superAdminOnlyRoutes = ['/api/admin'];
+
     if (superAdminOnlyRoutes.some(route => req.path.startsWith(route))) {
-      // Setup routes require super admin access
       if (subdomain !== 'admin' && subdomain !== 'main' && !req.path.startsWith('/api/admin')) {
-        return res.status(403).json({ 
+        return res.status(403).json({
           error: 'Access denied',
-          message: 'Setup dan admin panel hanya dapat diakses oleh super admin.'
+          message: 'Admin panel hanya dapat diakses oleh super admin.'
         });
       }
       req.isSuperAdmin = true;


### PR DESCRIPTION
## Summary
- allow tenant setup requests to bypass the super-admin-only guard in the tenant middleware
- keep the super admin restriction focused on /api/admin routes and update the denial message accordingly

## Testing
- npm run check *(fails: existing TypeScript errors in admin SaaS pages and Stripe integration routes)*

------
https://chatgpt.com/codex/tasks/task_e_68de24fe07c483269eae23b1d0d066d0