### PR TITLE
Fix duplicate finance totals declarations

### DIFF
--- a/server/financeManager.ts
+++ b/server/financeManager.ts
@@ -729,10 +729,6 @@ export class FinanceManager {
       totalCOGS = Number(cogsResult?.total || 0);
     }
 
-    const totalSalesRevenue = totalIncome;
-    const totalCOGS = Number(cogsResult?.total || 0);
-
-
     // Count
     const [countResult] = await db
       .select({ count: count() })


### PR DESCRIPTION
## Summary
- remove duplicate totalSalesRevenue and totalCOGS declarations from the finance manager to avoid esbuild errors during the server build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfe37805c88326b228fbfa189c0c9d