### PR TITLE
Fix finance manager gross profit calculation

### DIFF
--- a/server/financeManager.ts
+++ b/server/financeManager.ts
@@ -1130,9 +1130,9 @@ export class FinanceManager {
     const totalIncomeValue = Number(totalRevenue.toFixed(2));
     const totalExpenseValue = Number(totalExpenseNet.toFixed(2));
     const netProfitValue = Number((totalIncomeValue - totalExpenseValue).toFixed(2));
-    const grossProfitValue = Number((totalSalesRevenueValue - totalCOGSValue).toFixed(2));
     const totalSalesRevenueValue = Number(totalSalesRevenue.toFixed(2));
     const totalCOGSValue = Number(totalCOGS.toFixed(2));
+    const grossProfitValue = Number((totalSalesRevenueValue - totalCOGSValue).toFixed(2));
     const totalRefundsValue = Number(totalRefunds.toFixed(2));
 
     return {


### PR DESCRIPTION
## Summary
- ensure total sales revenue and COGS values are initialized before computing gross profit in FinanceManager

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00e20bbec83269561e3c6413b78f8