### PR TITLE
Include service profit in dashboard monthly total

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2549,8 +2549,9 @@ export class DatabaseStorage implements IStorage {
       .where(lowStockWhere);
 
     // Monthly profit calculated from POS transactions (harga jual - HPP)
-    let monthlyProfit = 0;
-    let monthlyProfitFromSales = false;
+    let monthlySalesRevenueValue = 0;
+    let monthlyCOGSValue = 0;
+    let monthlySalesProfit = 0;
 
     try {
       const monthlySalesWhere = clientId
@@ -2577,54 +2578,71 @@ export class DatabaseStorage implements IStorage {
         .where(monthlySalesWhere);
 
       if (monthlyPosSummary) {
-        const monthlySalesValue = Number(monthlyPosSummary.totalSales ?? 0);
-        const monthlyCOGSValue = Number(monthlyPosSummary.totalCOGS ?? 0);
-        monthlyProfit = Number((monthlySalesValue - monthlyCOGSValue).toFixed(2));
-        monthlyProfitFromSales = true;
+        monthlySalesRevenueValue = Number(monthlyPosSummary.totalSales ?? 0);
+        monthlyCOGSValue = Number(monthlyPosSummary.totalCOGS ?? 0);
       }
-      const { financeManager } = await import('./financeManager');
-      const summary = await financeManager.getSummary(startOfMonth, new Date());
-      monthlyProfit = Number(summary.grossProfit || 0);
     } catch (error) {
       console.error("Error calculating monthly POS profit from transactions:", error);
     }
 
-    if (!monthlyProfitFromSales) {
+    const fallbackGrossProfit = Number((monthlySalesRevenueValue - monthlyCOGSValue).toFixed(2));
+
+    try {
+      const { financeManager } = await import('./financeManager');
+      const summary = await financeManager.getSummary(startOfMonth, now);
+
+      const summarySalesRevenueValue = Number(summary.totalSalesRevenue ?? 0);
+      const resolvedSalesRevenueValue =
+        summarySalesRevenueValue !== 0 ? summarySalesRevenueValue : monthlySalesRevenueValue;
+
+      const summaryCOGSValue = Number(summary.totalCOGS ?? 0);
+      const resolvedCOGSValue = summaryCOGSValue !== 0 ? summaryCOGSValue : monthlyCOGSValue;
+
+      const fallbackSummaryGrossProfitValue = Number(
+        (resolvedSalesRevenueValue - resolvedCOGSValue).toFixed(2)
+      );
+
+      const summaryGrossProfitValue = Number(summary.grossProfit ?? 0);
+      const resolvedGrossProfitValue =
+        summaryGrossProfitValue !== 0
+          ? summaryGrossProfitValue
+          : fallbackSummaryGrossProfitValue !== 0
+            ? fallbackSummaryGrossProfitValue
+            : summaryGrossProfitValue;
+
+      monthlySalesProfit = resolvedGrossProfitValue;
+    } catch (error) {
+      console.error("Error getting monthly profit from finance manager:", error);
+    }
+
+    if (monthlySalesProfit === 0 && fallbackGrossProfit !== 0) {
+      monthlySalesProfit = fallbackGrossProfit;
+    }
+
+    if (monthlySalesProfit === 0) {
       try {
-        const { financeManager } = await import('./financeManager');
-        const summary = await financeManager.getSummary(startOfMonth, now);
-        monthlyProfit = Number(summary.grossProfit || 0);
-      } catch (error) {
-        console.error("Error getting monthly profit from finance manager:", error);
         // Fallback to simplified financial record calculation (harga jual - HPP)
         const confirmedCondition = eq(financialRecords.status, 'confirmed');
-        const monthlyIncomeWhere = clientId
-          ? and(
-              eq(financialRecords.type, 'income'),
-              gte(financialRecords.createdAt, startOfMonth),
-              confirmedCondition,
-              eq(financialRecords.clientId, clientId)
-            )
-          : and(
-              eq(financialRecords.type, 'income'),
-              gte(financialRecords.createdAt, startOfMonth),
-              confirmedCondition
-            );
+        const saleIncomeConditions = [
+          eq(financialRecords.type, 'income'),
+          eq(financialRecords.referenceType, 'sale'),
+          gte(financialRecords.createdAt, startOfMonth),
+          confirmedCondition
+        ];
+        const saleExpenseConditions = [
+          eq(financialRecords.type, 'expense'),
+          eq(financialRecords.referenceType, 'sale'),
+          gte(financialRecords.createdAt, startOfMonth),
+          confirmedCondition
+        ];
 
-        const monthlyCogsWhere = clientId
-          ? and(
-              eq(financialRecords.type, 'expense'),
-              sql`LOWER(${financialRecords.category}) = 'cost of goods sold'`,
-              gte(financialRecords.createdAt, startOfMonth),
-              confirmedCondition,
-              eq(financialRecords.clientId, clientId)
-            )
-          : and(
-              eq(financialRecords.type, 'expense'),
-              sql`LOWER(${financialRecords.category}) = 'cost of goods sold'`,
-              gte(financialRecords.createdAt, startOfMonth),
-              confirmedCondition
-            );
+        if (clientId) {
+          saleIncomeConditions.push(eq(financialRecords.clientId, clientId));
+          saleExpenseConditions.push(eq(financialRecords.clientId, clientId));
+        }
+
+        const monthlyIncomeWhere = and(...saleIncomeConditions);
+        const monthlyCogsWhere = and(...saleExpenseConditions);
 
         const [monthlyIncomeResult] = await db
           .select({ total: sum(financialRecords.amount) })
@@ -2638,9 +2656,58 @@ export class DatabaseStorage implements IStorage {
 
         const monthlyIncome = Number(monthlyIncomeResult.total || 0);
         const monthlyCOGS = Number(monthlyCogsResult.total || 0);
-        monthlyProfit = monthlyIncome - monthlyCOGS;
+        monthlySalesProfit = Number((monthlyIncome - monthlyCOGS).toFixed(2));
+      } catch (fallbackError) {
+        console.error("Error calculating monthly profit from financial records:", fallbackError);
       }
     }
+
+    let monthlyServiceProfit = 0;
+
+    try {
+      const confirmedCondition = eq(financialRecords.status, 'confirmed');
+      const serviceIncomeConditions = [
+        eq(financialRecords.type, 'income'),
+        or(
+          eq(financialRecords.referenceType, 'service_labor'),
+          eq(financialRecords.referenceType, 'service_parts_revenue')
+        ),
+        gte(financialRecords.createdAt, startOfMonth),
+        lte(financialRecords.createdAt, now),
+        confirmedCondition
+      ];
+
+      const serviceCostConditions = [
+        eq(financialRecords.type, 'expense'),
+        eq(financialRecords.referenceType, 'service_parts_cost'),
+        gte(financialRecords.createdAt, startOfMonth),
+        lte(financialRecords.createdAt, now),
+        confirmedCondition
+      ];
+
+      if (clientId) {
+        serviceIncomeConditions.push(eq(financialRecords.clientId, clientId));
+        serviceCostConditions.push(eq(financialRecords.clientId, clientId));
+      }
+
+      const [serviceIncomeResult] = await db
+        .select({ total: sum(financialRecords.amount) })
+        .from(financialRecords)
+        .where(and(...serviceIncomeConditions));
+
+      const [serviceCostResult] = await db
+        .select({ total: sum(financialRecords.amount) })
+        .from(financialRecords)
+        .where(and(...serviceCostConditions));
+
+      const serviceIncomeTotal = Number(serviceIncomeResult.total || 0);
+      const serviceCostTotal = Number(serviceCostResult.total || 0);
+      monthlyServiceProfit = Number((serviceIncomeTotal - serviceCostTotal).toFixed(2));
+    } catch (error) {
+      console.error("Error calculating monthly service profit:", error);
+    }
+
+    const monthlyProfit = Number((monthlySalesProfit + monthlyServiceProfit).toFixed(2));
 
     // Get WhatsApp connection status from store config
     const storeConfig = await this.getStoreConfig();


### PR DESCRIPTION
## Summary
- ensure the dashboard monthly profit aggregates POS gross profit together with confirmed service profit
- limit the POS fallback calculation to confirmed sale records so service income is not double-counted
- add confirmed service income and cost queries to compute the monthly service profit contribution

## Testing
- npm run check *(fails: existing TypeScript errors in admin SaaS modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e019e415f483268bd77b65cc3567bf