### PR TITLE
Align service statuses with new workflow

### DIFF
--- a/client/src/components/ServiceCancellationModal.tsx
+++ b/client/src/components/ServiceCancellationModal.tsx
@@ -52,15 +52,15 @@ const getCancellationScenarios = (ticket: any): CancellationType[] => {
   const status = ticket.status;
   const hasWarranty = ticket.warrantyDuration && ticket.warrantyDuration > 0;
   
-  // For tickets not yet completed (pending, checking, in-progress, waiting-*)
-  if (['pending', 'checking', 'in-progress', 'waiting-technician', 'testing', 'waiting-confirmation', 'waiting-parts'].includes(status)) {
+  // For tickets not yet selesai/sudah_diambil
+  if (['sedang_dicek', 'menunggu_konfirmasi', 'menunggu_sparepart', 'sedang_dikerjakan'].includes(status)) {
     return ['before_completed'];
   }
-  
-  // For completed/delivered tickets
-  if (['completed', 'delivered'].includes(status)) {
+
+  // For selesai/sudah diambil tickets
+  if (['selesai', 'sudah_diambil'].includes(status)) {
     const scenarios: CancellationType[] = ['after_completed'];
-    
+
     // Add warranty refund option if ticket has warranty
     if (hasWarranty) {
       scenarios.push('warranty_refund');

--- a/client/src/components/ServicePaymentReceipt.tsx
+++ b/client/src/components/ServicePaymentReceipt.tsx
@@ -583,8 +583,8 @@ export default function ServicePaymentReceipt({
                     <div className="flex justify-between">
                       <span className="text-gray-600">Status:</span>
                       <span className="font-semibold text-green-600">
-                        {serviceTicket.status === 'completed' ? 'SELESAI' : 
-                         serviceTicket.status === 'delivered' ? 'DIAMBIL' : 'SELESAI'}
+                        {serviceTicket.status === 'selesai' ? 'SELESAI' :
+                         serviceTicket.status === 'sudah_diambil' ? 'DIAMBIL' : 'SELESAI'}
                       </span>
                     </div>
                     {technician && (

--- a/client/src/components/ServiceReceipt.tsx
+++ b/client/src/components/ServiceReceipt.tsx
@@ -48,12 +48,13 @@ interface ServiceReceiptProps {
 }
 
 const statusConfig = {
-  pending: 'Menunggu',
-  'in-progress': 'Dikerjakan',
-  'waiting-parts': 'Menunggu Sparepart',
-  'waiting-payment': 'Menunggu Pembayaran',
-  completed: 'Selesai',
-  cancelled: 'Dibatalkan',
+  sedang_dicek: 'Sedang Dicek',
+  menunggu_konfirmasi: 'Menunggu Konfirmasi',
+  menunggu_sparepart: 'Menunggu Sparepart',
+  sedang_dikerjakan: 'Sedang Dikerjakan',
+  selesai: 'Selesai',
+  sudah_diambil: 'Sudah Diambil',
+  cencel: 'Cencel',
 };
 
 const paperSizes = {

--- a/client/src/components/ServiceStatusTracker.tsx
+++ b/client/src/components/ServiceStatusTracker.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { CheckCircle, Clock, AlertCircle, Package, Settings, TestTube, FileText, X } from 'lucide-react';
+import { CheckCircle, Clock, Package, Settings, FileText, X } from 'lucide-react';
 
 interface ServiceStep {
   id: string;
@@ -23,47 +23,15 @@ interface ServiceStatusTrackerProps {
 
 const serviceSteps: ServiceStep[] = [
   {
-    id: 'received',
-    label: 'Belum Cek',
+    id: 'sedang_dicek',
+    label: 'Sedang Dicek',
     status: 'pending',
     icon: Clock,
     color: 'text-blue-700',
     bgColor: 'bg-blue-100'
   },
   {
-    id: 'checking',
-    label: 'Sedang Cek',
-    status: 'pending',
-    icon: AlertCircle,
-    color: 'text-sky-700',
-    bgColor: 'bg-sky-100'
-  },
-  {
-    id: 'in-progress',
-    label: 'Sedang Dikerjakan',
-    status: 'pending',
-    icon: Settings,
-    color: 'text-green-700',
-    bgColor: 'bg-green-100'
-  },
-  {
-    id: 'waiting-technician',
-    label: 'Ditunggu MITRA Teknik',
-    status: 'pending',
-    icon: AlertCircle,
-    color: 'text-gray-700',
-    bgColor: 'bg-gray-100'
-  },
-  {
-    id: 'testing',
-    label: 'Sedang Tes',
-    status: 'pending',
-    icon: TestTube,
-    color: 'text-gray-700',
-    bgColor: 'bg-gray-100'
-  },
-  {
-    id: 'waiting-confirmation',
+    id: 'menunggu_konfirmasi',
     label: 'Menunggu Konfirmasi',
     status: 'pending',
     icon: FileText,
@@ -71,7 +39,7 @@ const serviceSteps: ServiceStep[] = [
     bgColor: 'bg-red-100'
   },
   {
-    id: 'waiting-parts',
+    id: 'menunggu_sparepart',
     label: 'Menunggu Sparepart',
     status: 'pending',
     icon: Package,
@@ -79,27 +47,40 @@ const serviceSteps: ServiceStep[] = [
     bgColor: 'bg-orange-100'
   },
   {
-    id: 'completed',
+    id: 'sedang_dikerjakan',
+    label: 'Sedang Dikerjakan',
+    status: 'pending',
+    icon: Settings,
+    color: 'text-green-700',
+    bgColor: 'bg-green-100'
+  },
+  {
+    id: 'selesai',
     label: 'Selesai',
     status: 'pending',
     icon: CheckCircle,
     color: 'text-emerald-700',
     bgColor: 'bg-emerald-100'
+  },
+  {
+    id: 'sudah_diambil',
+    label: 'Sudah Diambil',
+    status: 'pending',
+    icon: CheckCircle,
+    color: 'text-purple-700',
+    bgColor: 'bg-purple-100'
   }
 ];
 
 // Map status dari database ke langkah-langkah service
 const statusMapping: Record<string, number> = {
-  'pending': 0,           // Belum Cek
-  'checking': 1,          // Sedang Cek  
-  'in-progress': 2,       // Sedang Dikerjakan
-  'waiting-technician': 3, // Ditunggu MITRA Teknik
-  'testing': 4,           // Sedang Tes
-  'waiting-confirmation': 5, // Menunggu Konfirmasi
-  'waiting-parts': 6,     // Menunggu Sparepart
-  'completed': 7,         // Selesai
-  'delivered': 7,         // Selesai (sudah diambil)
-  'cancelled': -1         // Dibatalkan
+  sedang_dicek: 0,
+  menunggu_konfirmasi: 1,
+  menunggu_sparepart: 2,
+  sedang_dikerjakan: 3,
+  selesai: 4,
+  sudah_diambil: 5,
+  cencel: -1,
 };
 
 export default function ServiceStatusTracker({ 
@@ -116,7 +97,7 @@ export default function ServiceStatusTracker({
   const getStepStatus = (stepIndex: number): 'completed' | 'current' | 'pending' | 'waiting' => {
     const currentIndex = getCurrentStepIndex();
     
-    if (currentStatus === 'cancelled') {
+    if (currentStatus === 'cencel') {
       return 'waiting';
     }
     

--- a/client/src/components/dashboard/service-status.tsx
+++ b/client/src/components/dashboard/service-status.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Laptop, Clock, CheckCircle, AlertTriangle } from "lucide-react";
+import { Laptop, Clock, CheckCircle, AlertTriangle, Package } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { formatDateShort } from '@shared/utils/timezone';
 
@@ -15,50 +15,21 @@ export default function ServiceStatus() {
     retry: false,
   });
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'pending':
-        return 'secondary';
-      case 'in_progress':
-        return 'default';
-      case 'completed':
-        return 'secondary';
-      case 'delivered':
-        return 'secondary';
-      default:
-        return 'destructive';
-    }
+  const statusConfig: Record<string, { variant: "default" | "secondary" | "destructive" | "outline"; icon: typeof Clock; label: string }> = {
+    sedang_dicek: { variant: "secondary", icon: Clock, label: "Sedang Dicek" },
+    menunggu_konfirmasi: { variant: "destructive", icon: AlertTriangle, label: "Menunggu Konfirmasi" },
+    menunggu_sparepart: { variant: "secondary", icon: Package, label: "Menunggu Sparepart" },
+    sedang_dikerjakan: { variant: "default", icon: Clock, label: "Sedang Dikerjakan" },
+    selesai: { variant: "default", icon: CheckCircle, label: "Selesai" },
+    sudah_diambil: { variant: "secondary", icon: CheckCircle, label: "Sudah Diambil" },
+    cencel: { variant: "destructive", icon: AlertTriangle, label: "Cencel" },
   };
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'pending':
-        return Clock;
-      case 'in_progress':
-        return Clock;
-      case 'completed':
-        return CheckCircle;
-      case 'delivered':
-        return CheckCircle;
-      default:
-        return AlertTriangle;
-    }
-  };
+  const getStatusColor = (status: string) => statusConfig[status]?.variant || 'secondary';
 
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'pending':
-        return 'Menunggu';
-      case 'in_progress':
-        return 'Dikerjakan';
-      case 'completed':
-        return 'Selesai';
-      case 'delivered':
-        return 'Terkirim';
-      default:
-        return 'Tertunda';
-    }
-  };
+  const getStatusIcon = (status: string) => statusConfig[status]?.icon || AlertTriangle;
+
+  const getStatusText = (status: string) => statusConfig[status]?.label || 'Status Tidak Dikenal';
 
   return (
     <Card className="shadow-sm">

--- a/client/src/pages/ServiceStatus.tsx
+++ b/client/src/pages/ServiceStatus.tsx
@@ -6,23 +6,19 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Search, Clock, CheckCircle, AlertCircle, Package, Calendar, Receipt, Settings, TestTube, FileText } from "lucide-react";
+import { Search, Clock, CheckCircle, AlertCircle, Package, Calendar, Receipt, Settings } from "lucide-react";
 import { formatDateLong } from '@shared/utils/timezone';
 import ServiceStatusTracker from "@/components/ServiceStatusTracker";
 
 const statusConfig = {
-  pending: { label: 'Belum Cek', color: 'bg-yellow-500', icon: Clock },
-  checking: { label: 'Sedang Cek', color: 'bg-sky-500', icon: AlertCircle },
-  'in-progress': { label: 'Sedang Dikerjakan', color: 'bg-blue-500', icon: Settings },
-  'waiting-technician': { label: 'Ditunggu MITRA Teknik', color: 'bg-gray-500', icon: AlertCircle },
-  testing: { label: 'Sedang Tes', color: 'bg-indigo-500', icon: TestTube },
-  'waiting-confirmation': { label: 'Menunggu Konfirmasi', color: 'bg-red-500', icon: FileText },
-  'waiting-parts': { label: 'Menunggu Sparepart', color: 'bg-orange-500', icon: Package },
-  'waiting-payment': { label: 'Menunggu Pembayaran', color: 'bg-purple-500', icon: Receipt },
-  completed: { label: 'Selesai', color: 'bg-green-500', icon: CheckCircle },
-  delivered: { label: 'Sudah Diambil', color: 'bg-emerald-500', icon: CheckCircle },
-  cancelled: { label: 'Dibatalkan', color: 'bg-red-500', icon: AlertCircle },
-};
+  sedang_dicek: { label: 'Sedang Dicek', color: 'bg-yellow-500', icon: Clock },
+  menunggu_konfirmasi: { label: 'Menunggu Konfirmasi', color: 'bg-red-500', icon: AlertCircle },
+  menunggu_sparepart: { label: 'Menunggu Sparepart', color: 'bg-orange-500', icon: Package },
+  sedang_dikerjakan: { label: 'Sedang Dikerjakan', color: 'bg-blue-500', icon: Settings },
+  selesai: { label: 'Selesai', color: 'bg-green-500', icon: CheckCircle },
+  sudah_diambil: { label: 'Sudah Diambil', color: 'bg-emerald-500', icon: CheckCircle },
+  cencel: { label: 'Cencel', color: 'bg-red-600', icon: AlertCircle },
+} as const;
 
 export default function ServiceStatus() {
   const [serviceNumber, setServiceNumber] = useState("");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2218,16 +2218,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Status-specific validation based on cancellation type  
-      if (cancellationType === 'after_completed' && existingTicket.status !== 'completed' && existingTicket.status !== 'delivered') {
-        return res.status(400).json({ 
-          message: "Cannot cancel with 'after_completed' type - service ticket is not completed" 
+      if (cancellationType === 'after_completed' && existingTicket.status !== 'selesai' && existingTicket.status !== 'sudah_diambil') {
+        return res.status(400).json({
+          message: "Cannot cancel with 'after_completed' type - service ticket is not completed"
         });
       }
-      
-      if (cancellationType === 'warranty_refund' && existingTicket.status !== 'warranty_claim') {
-        if (existingTicket.status !== 'completed' && existingTicket.status !== 'delivered') {
-          return res.status(400).json({ 
-            message: "Cannot cancel with 'warranty_refund' type - service ticket must be completed or under warranty claim" 
+
+      if (cancellationType === 'warranty_refund') {
+        if (existingTicket.status !== 'selesai' && existingTicket.status !== 'sudah_diambil') {
+          return res.status(400).json({
+            message: "Cannot cancel with 'warranty_refund' type - service ticket must be completed or under warranty claim"
           });
         }
       }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1579,7 +1579,7 @@ export class DatabaseStorage implements IStorage {
       })
       .from(serviceTickets)
       .leftJoin(customers, eq(serviceTickets.customerId, customers.id))
-      .where(sql`${serviceTickets.status} != 'completed' AND ${serviceTickets.status} != 'cancelled'`)
+      .where(sql`${serviceTickets.status} != 'selesai' AND ${serviceTickets.status} != 'sudah_diambil' AND ${serviceTickets.status} != 'cencel'`)
       .orderBy(desc(serviceTickets.createdAt));
     
     return tickets.map(ticket => ({
@@ -1631,8 +1631,8 @@ export class DatabaseStorage implements IStorage {
             totalPrice: totalPrice
           });
           
-          // Only update stock and record movement for completed/delivered status
-          if (ticket.status === 'completed' || ticket.status === 'delivered') {
+          // Only update stock and record movement for selesai/sudah_diambil status
+          if (ticket.status === 'selesai' || ticket.status === 'sudah_diambil') {
             const currentStock = product.stock || 0;
             
             // Check stock for completed services - allow negative stock but warn
@@ -1692,7 +1692,7 @@ export class DatabaseStorage implements IStorage {
       }
       
       // Auto-record financial transactions for completed services
-      if (ticket && (ticket.status === 'completed' || ticket.status === 'delivered')) {
+      if (ticket && (ticket.status === 'selesai' || ticket.status === 'sudah_diambil')) {
         try {
           const { financeManager } = await import('./financeManager');
           
@@ -1765,7 +1765,7 @@ export class DatabaseStorage implements IStorage {
           return { success: false, message: 'Service ticket not found' };
         }
 
-        if (ticket.status === 'cancelled') {
+        if (ticket.status === 'cencel') {
           return { success: false, message: 'Service ticket is already cancelled' };
         }
 
@@ -1790,7 +1790,7 @@ export class DatabaseStorage implements IStorage {
 
         // Update service ticket dengan data pembatalan
         await tx.update(serviceTickets).set({
-          status: 'cancelled',
+          status: 'cencel',
           cancellationFee: data.cancellationFee,
           cancellationReason: data.cancellationReason,
           cancellationType: data.cancellationType,
@@ -2517,13 +2517,15 @@ export class DatabaseStorage implements IStorage {
     // Active services
     const activeServicesWhere = clientId
       ? and(
-          ne(serviceTickets.status, 'completed'),
-          ne(serviceTickets.status, 'cancelled'),
+          ne(serviceTickets.status, 'selesai'),
+          ne(serviceTickets.status, 'sudah_diambil'),
+          ne(serviceTickets.status, 'cencel'),
           eq(serviceTickets.clientId, clientId)
         )
       : and(
-          ne(serviceTickets.status, 'completed'),
-          ne(serviceTickets.status, 'cancelled')
+          ne(serviceTickets.status, 'selesai'),
+          ne(serviceTickets.status, 'sudah_diambil'),
+          ne(serviceTickets.status, 'cencel')
         );
 
     const [activeServicesResult] = await db
@@ -2963,7 +2965,7 @@ export class DatabaseStorage implements IStorage {
       }
 
       // Create new service ticket for warranty service
-      const warrantyServiceData: InsertServiceTicket = {
+        const warrantyServiceData: InsertServiceTicket = {
         ticketNumber: `WS-${Date.now()}-${Math.random().toString(36).substr(2, 4).toUpperCase()}`,
         customerId: customerId,
         deviceType: originalTicket.deviceType,
@@ -2971,7 +2973,7 @@ export class DatabaseStorage implements IStorage {
         deviceModel: originalTicket.deviceModel,
         serialNumber: originalTicket.serialNumber,
         problem: `Warranty Service - Follow up for ticket: ${originalTicket.ticketNumber}`,
-        status: 'pending',
+        status: 'sedang_dicek',
         laborCost: '0.00', // Free labor for warranty service
         estimatedCompletion: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
         warrantyDuration: originalTicket.warrantyDuration || 90, // Default 90 days
@@ -2984,8 +2986,8 @@ export class DatabaseStorage implements IStorage {
       // Update original service ticket status to indicate warranty claim
       await db
         .update(serviceTickets)
-        .set({ 
-          status: 'warranty_claim' as any,
+        .set({
+          status: 'selesai',
           updatedAt: new Date(),
         })
         .where(eq(serviceTickets.id, originalServiceTicketId));

--- a/server/whatsappService.ts
+++ b/server/whatsappService.ts
@@ -290,15 +290,14 @@ export class WhatsAppService {
 
     // Status label
     const statusLabels = {
-      'pending': 'Menunggu Pemeriksaan',
-      'checking': 'Sedang Dicek',
-      'in-progress': 'Sedang Dikerjakan',
-      'waiting-parts': 'Menunggu Sparepart',
-      'waiting-payment': 'Menunggu Pembayaran',
-      'completed': 'Selesai',
-      'delivered': 'Sudah Diambil',
-      'cancelled': 'Dibatalkan'
-    };
+      sedang_dicek: 'Sedang Dicek',
+      menunggu_konfirmasi: 'Menunggu Konfirmasi',
+      menunggu_sparepart: 'Menunggu Sparepart',
+      sedang_dikerjakan: 'Sedang Dikerjakan',
+      selesai: 'Selesai',
+      sudah_diambil: 'Sudah Diambil',
+      cencel: 'Dibatalkan'
+    } as const;
 
     // Build spare parts info if available
     let sparepartsInfo = '';
@@ -415,37 +414,32 @@ ${storeConfig?.email ? `📧 ${storeConfig.email}` : ''}`;
     let nextSteps = '';
     let estimatedCostInfo = '';
     switch (serviceTicket.status) {
-      case 'checking':
+      case 'sedang_dicek':
         statusText = 'SEDANG DICEK';
         emoji = '🔍';
         nextSteps = 'Tim teknisi kami sedang memeriksa perangkat Anda untuk menentukan kerusakan dan solusi yang tepat.';
         break;
-      case 'in-progress':
+      case 'sedang_dikerjakan':
         statusText = 'SEDANG DIKERJAKAN';
         emoji = '🔧';
         nextSteps = 'Perangkat Anda sedang dalam proses perbaikan. Tim teknisi kami bekerja untuk menyelesaikan masalah.';
         break;
-      case 'completed':
+      case 'selesai':
         statusText = 'SELESAI DIKERJAKAN';
         emoji = '✅';
         nextSteps = 'Perbaikan telah selesai! Perangkat siap diambil. Silakan datang ke toko dengan membawa tanda terima.';
         break;
-      case 'cancelled':
+      case 'cencel':
         statusText = 'DIBATALKAN';
         emoji = '❌';
         nextSteps = 'Service dibatalkan sesuai permintaan. Jika ada pertanyaan, silakan hubungi kami.';
         break;
-      case 'waiting-parts':
+      case 'menunggu_sparepart':
         statusText = 'MENUNGGU SPAREPART';
         emoji = '📦';
         nextSteps = 'Kami sedang memesan sparepart yang diperlukan. Akan ada update setelah sparepart tersedia.';
         break;
-      case 'waiting-payment':
-        statusText = 'MENUNGGU PEMBAYARAN';
-        emoji = '💳';
-        nextSteps = 'Perbaikan selesai, silakan lakukan pembayaran untuk mengambil perangkat.';
-        break;
-      case 'waiting-confirmation':
+      case 'menunggu_konfirmasi':
         statusText = 'MENUNGGU KONFIRMASI';
         emoji = '❓';
         nextSteps = 'Kami memerlukan konfirmasi dari Anda untuk melanjutkan perbaikan. Silakan hubungi kami.';
@@ -454,16 +448,11 @@ ${storeConfig?.email ? `📧 ${storeConfig.email}` : ''}`;
           estimatedCostInfo = `\n\n💰 *Estimasi Biaya Service:* ${formatCurrency(serviceTicket.estimatedCost)}`;
         }
         break;
-      case 'testing':
-        statusText = 'SEDANG TES';
-        emoji = '🧪';
-        nextSteps = 'Sedang dilakukan pengujian untuk memastikan perbaikan berfungsi dengan baik.';
+      case 'sudah_diambil':
+        statusText = 'SUDAH DIAMBIL';
+        emoji = '📦';
+        nextSteps = 'Perangkat Anda telah diambil. Terima kasih telah menggunakan layanan kami!';
         break;
-        case 'delivered':
-          statusText = 'SUDAH DIAMBIL';
-          emoji = '📦';
-          nextSteps = 'Perangkat Anda telah diambil. Terima kasih telah menggunakan layanan kami!';
-          break;
       default:
         statusText = 'DIUPDATE';
         emoji = '🔄';
@@ -518,7 +507,7 @@ ${storeConfig?.email ? `📧 ${storeConfig.email}` : ''}`;
 
     // Completion info for completed status
     let completionInfo = '';
-    if (serviceTicket.status === 'completed' && serviceTicket.completedAt) {
+    if (serviceTicket.status === 'selesai' && serviceTicket.completedAt) {
       const completedDate = new Date(serviceTicket.completedAt).toLocaleDateString('id-ID', {
         weekday: 'long',
         year: 'numeric',
@@ -538,7 +527,7 @@ ${storeConfig?.email ? `📧 ${storeConfig.email}` : ''}`;
     warrantyInfo = `\n🛡️ **GARANSI SERVICE:**\n${serviceTicket.warrantyPeriod}`;
   }
 
-  const message = `${emoji} **UPDATE STATUS SERVICE**\n\nHalo ${customer.name},\n\nAda update untuk service laptop Anda:\n\n📋 **INFORMASI SERVICE:**\n📝 Nomor Service: *${serviceTicket.ticketNumber}*\n📅 Update Terakhir: ${updateDate}\n⏰ Status: *${statusText}*${estimatedCostInfo}\n\n💻 **PERANGKAT:**\n${serviceTicket.deviceType}${serviceTicket.deviceBrand ? ` - ${serviceTicket.deviceBrand}` : ''}${serviceTicket.deviceModel ? ` ${serviceTicket.deviceModel}` : ''}\n\n🔍 **MASALAH:**\n${serviceTicket.problem}${progressInfo}${completionInfo}\n${warrantyInfo}\n\n💬 **LANGKAH SELANJUTNYA:**\n${nextSteps}\n\n🔍 **CEK STATUS DETAIL:**\nUntuk informasi lebih lengkap, kunjungi:\n${statusUrl}?ticket=${serviceTicket.ticketNumber}${warrantyInfo ? `&garansi=${encodeURIComponent(serviceTicket.warrantyDescription || serviceTicket.warrantyPeriod)}` : ''}\n\n${serviceTicket.status === 'completed' ? '⚠️ **PENTING:** Harap bawa tanda terima saat pengambilan!' : '📞 **INFO:** Kami akan update jika ada perkembangan baru.'}\n\n---\n🏪 **${storeConfig?.name || 'LaptopPOS Service Center'}**\n📞 ${storeConfig?.phone || 'Telepon Toko'}`;
+  const message = `${emoji} **UPDATE STATUS SERVICE**\n\nHalo ${customer.name},\n\nAda update untuk service laptop Anda:\n\n📋 **INFORMASI SERVICE:**\n📝 Nomor Service: *${serviceTicket.ticketNumber}*\n📅 Update Terakhir: ${updateDate}\n⏰ Status: *${statusText}*${estimatedCostInfo}\n\n💻 **PERANGKAT:**\n${serviceTicket.deviceType}${serviceTicket.deviceBrand ? ` - ${serviceTicket.deviceBrand}` : ''}${serviceTicket.deviceModel ? ` ${serviceTicket.deviceModel}` : ''}\n\n🔍 **MASALAH:**\n${serviceTicket.problem}${progressInfo}${completionInfo}\n${warrantyInfo}\n\n💬 **LANGKAH SELANJUTNYA:**\n${nextSteps}\n\n🔍 **CEK STATUS DETAIL:**\nUntuk informasi lebih lengkap, kunjungi:\n${statusUrl}?ticket=${serviceTicket.ticketNumber}${warrantyInfo ? `&garansi=${encodeURIComponent(serviceTicket.warrantyDescription || serviceTicket.warrantyPeriod)}` : ''}\n\n${serviceTicket.status === 'selesai' ? '⚠️ **PENTING:** Harap bawa tanda terima saat pengambilan!' : '📞 **INFO:** Kami akan update jika ada perkembangan baru.'}\n\n---\n🏪 **${storeConfig?.name || 'LaptopPOS Service Center'}**\n📞 ${storeConfig?.phone || 'Telepon Toko'}`;
 
     try {
       const result = await this.sendMessage(customerPhone, message);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -35,7 +35,15 @@ export const sessions = pgTable(
 export const userRoleEnum = pgEnum('user_role', ['super_admin', 'admin', 'kasir', 'teknisi', 'purchasing', 'finance', 'owner']);
 export const transactionTypeEnum = pgEnum('transaction_type', ['sale', 'service', 'purchase', 'return']);
 export const paymentMethodEnum = pgEnum('payment_method', ['cash', 'transfer', 'qris', 'installment']);
-export const serviceStatusEnum = pgEnum('service_status', ['pending', 'checking', 'in-progress', 'waiting-technician', 'testing', 'waiting-confirmation', 'waiting-parts', 'completed', 'delivered', 'cancelled', 'warranty_claim']);
+export const serviceStatusEnum = pgEnum('service_status', [
+  'sedang_dicek',
+  'menunggu_konfirmasi',
+  'menunggu_sparepart',
+  'sedang_dikerjakan',
+  'selesai',
+  'sudah_diambil',
+  'cencel'
+]);
 export const stockMovementTypeEnum = pgEnum('stock_movement_type', ['in', 'out', 'adjustment']);
 export const stockReferenceTypeEnum = pgEnum('stock_reference_type', ['sale', 'service', 'purchase', 'adjustment', 'return']);
 export const warrantyClaimTypeEnum = pgEnum('warranty_claim_type', ['service', 'sales_return']);
@@ -271,7 +279,7 @@ export const serviceTickets = pgTable("service_tickets", {
   actualCost: decimal("actual_cost", { precision: 12, scale: 2 }),
   laborCost: decimal("labor_cost", { precision: 12, scale: 2 }),
   partsCost: decimal("parts_cost", { precision: 12, scale: 2 }),
-  status: serviceStatusEnum("status").default('pending'),
+  status: serviceStatusEnum("status").default('sedang_dicek'),
   technicianId: varchar("technician_id").references(() => users.id),
   estimatedCompletion: timestamp("estimated_completion", { withTimezone: true }).default(sql`now()`),
   completedAt: timestamp("completed_at", { withTimezone: true }).default(sql`now()`),

--- a/shared/service-cancellation-schema.ts
+++ b/shared/service-cancellation-schema.ts
@@ -52,13 +52,13 @@ export const validateCancellationBusinessRules = {
       return { isValid: false, errors };
     }
     
-    if (ticket.status === 'cancelled') {
+    if (ticket.status === 'cencel') {
       errors.push("Service ticket sudah dibatalkan sebelumnya");
       return { isValid: false, errors };
     }
-    
+
     // Additional business rules can be added here
-    if (ticket.status === 'delivered' && ticket.deliveredAt) {
+    if (ticket.status === 'sudah_diambil' && ticket.deliveredAt) {
       const deliveredDate = new Date(ticket.deliveredAt);
       const now = new Date();
       const daysDifference = Math.floor((now.getTime() - deliveredDate.getTime()) / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
## Summary
- replace the service status enum with the requested workflow values and default
- update backend cancellation, reporting, and WhatsApp logic to honor the new status names
- adjust service management UI components, filters, and receipts to surface only the supported statuses

## Testing
- `npm run check` *(fails: existing type errors in admin SaaS modules and duplicate identifiers in server controllers/routes)*

------
https://chatgpt.com/codex/tasks/task_e_68e0229817248326b927bc302b192847