### PR TITLE
Handle unknown service ticket statuses

### DIFF
--- a/client/src/pages/service-tickets.tsx
+++ b/client/src/pages/service-tickets.tsx
@@ -660,8 +660,16 @@ export default function ServiceTickets() {
                   <TableBody>
                     {filteredTickets.map((ticket: ServiceTicket) => {
                       const customer = (customers as Customer[]).find(c => c.id === ticket.customerId);
-                      const statusConfig = statusColors[(ticket.status || 'sedang_dicek') as ServiceTicketStatus];
+                      const rawStatus = (ticket.status || 'sedang_dicek') as string;
+                      const isKnownStatus = rawStatus in statusColors;
+                      const safeStatus = (isKnownStatus
+                        ? rawStatus
+                        : 'sedang_dicek') as ServiceTicketStatus;
+                      const statusConfig = statusColors[safeStatus];
                       const StatusIcon = statusConfig.icon;
+                      const statusLabel = isKnownStatus
+                        ? statusLabels[safeStatus]
+                        : 'Status Tidak Dikenal';
 
                       return (
                         <TableRow key={ticket.id}>
@@ -699,7 +707,7 @@ export default function ServiceTickets() {
                             <div className={`flex items-center space-x-2 px-2 py-1 rounded-full ${statusConfig.bg} w-fit`}>
                               <StatusIcon className={`w-3 h-3 ${statusConfig.text}`} />
                               <span className={`text-xs font-medium ${statusConfig.text}`} data-testid={`ticket-status-${ticket.id}`}>
-                                {statusLabels[(ticket.status || 'sedang_dicek') as ServiceTicketStatus]}
+                                {statusLabel}
                               </span>
                             </div>
                           </TableCell>


### PR DESCRIPTION
## Summary
- add defensive fallbacks when mapping service ticket statuses so the service page keeps rendering even if the backend sends a new status value

## Testing
- npm run check *(fails: pre-existing TypeScript errors in admin-saas and saas server routes)*

------
https://chatgpt.com/codex/tasks/task_e_68e02a0b3a6483269c0d885a57cfe53d