### PR TITLE
Prevent setup screen from blocking when status fails

### DIFF
--- a/client/src/hooks/useSetup.ts
+++ b/client/src/hooks/useSetup.ts
@@ -22,8 +22,12 @@ export function useSetup() {
   });
 
   const isSetupCompleted = setupStatus?.setupCompleted ?? false;
-  // Show setup if not completed OR if there's an error (assume fresh installation)
-  const needsSetup = (!isSetupCompleted && !isSetupLoading) || (!setupStatus && !isSetupLoading);
+
+  // Only show the setup wizard when the API explicitly tells us setup isn't complete.
+  // When the status request fails (e.g. server offline), fall back to regular auth flow
+  // so the app doesn't get stuck on a blank setup screen.
+  const needsSetup =
+    !isSetupLoading && setupStatus ? !isSetupCompleted : false;
 
   // Debug logging for development
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Summary
- ensure the setup status hook only redirects to the setup wizard when the API explicitly reports that setup is incomplete
- fall back to the authentication flow when the status request errors so the UI is no longer blank

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02fc19cc88326871404fa1fee79da