### PR TITLE
Align service status values with Postgres enum

### DIFF
--- a/client/src/components/ServicePaymentReceipt.tsx
+++ b/client/src/components/ServicePaymentReceipt.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Printer, Download, X } from 'lucide-react';
 import QRCode from 'qrcode';
 import { formatDateShort, formatDateWithTime, formatDateForDisplay } from '@shared/utils/timezone';
+import { SERVICE_STATUS_LABELS, normalizeServiceStatus } from "@shared/service-status";
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
 
@@ -583,8 +584,7 @@ export default function ServicePaymentReceipt({
                     <div className="flex justify-between">
                       <span className="text-gray-600">Status:</span>
                       <span className="font-semibold text-green-600">
-                        {serviceTicket.status === 'selesai' ? 'SELESAI' :
-                         serviceTicket.status === 'sudah_diambil' ? 'DIAMBIL' : 'SELESAI'}
+                        {(SERVICE_STATUS_LABELS[normalizeServiceStatus(serviceTicket.status) ?? 'completed'] || 'Selesai').toUpperCase()}
                       </span>
                     </div>
                     {technician && (

--- a/client/src/components/ServiceReceipt.tsx
+++ b/client/src/components/ServiceReceipt.tsx
@@ -5,6 +5,7 @@ import { Separator } from "@/components/ui/separator";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
 import { formatDateWithTime, formatDateShort } from '@shared/utils/timezone';
+import { SERVICE_STATUS_LABELS, normalizeServiceStatus } from "@shared/service-status";
 import { Printer, Download, FileText } from "lucide-react";
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
@@ -47,14 +48,9 @@ interface ServiceReceiptProps {
   };
 }
 
-const statusConfig = {
-  sedang_dicek: 'Sedang Dicek',
-  menunggu_konfirmasi: 'Menunggu Konfirmasi',
-  menunggu_sparepart: 'Menunggu Sparepart',
-  sedang_dikerjakan: 'Sedang Dikerjakan',
-  selesai: 'Selesai',
-  sudah_diambil: 'Sudah Diambil',
-  cencel: 'Cencel',
+const getStatusText = (status: string) => {
+  const normalized = normalizeServiceStatus(status) ?? 'pending';
+  return SERVICE_STATUS_LABELS[normalized];
 };
 
 const paperSizes = {
@@ -291,7 +287,7 @@ export default function ServiceReceipt({ serviceData, storeConfig }: ServiceRece
                 )}
                 <div className="flex justify-between">
                   <span className="font-bold">Status:</span>
-                  <span data-testid="text-service-status">{statusConfig[serviceData.status as keyof typeof statusConfig]}</span>
+                  <span data-testid="text-service-status">{getStatusText(serviceData.status)}</span>
                 </div>
               </div>
 

--- a/client/src/pages/ServiceStatus.tsx
+++ b/client/src/pages/ServiceStatus.tsx
@@ -8,17 +8,21 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Search, Clock, CheckCircle, AlertCircle, Package, Calendar, Receipt, Settings } from "lucide-react";
 import { formatDateLong } from '@shared/utils/timezone';
+import { SERVICE_STATUS_LABELS, normalizeServiceStatus, type ServiceStatus } from "@shared/service-status";
 import ServiceStatusTracker from "@/components/ServiceStatusTracker";
 
-const statusConfig = {
-  sedang_dicek: { label: 'Sedang Dicek', color: 'bg-yellow-500', icon: Clock },
-  menunggu_konfirmasi: { label: 'Menunggu Konfirmasi', color: 'bg-red-500', icon: AlertCircle },
-  menunggu_sparepart: { label: 'Menunggu Sparepart', color: 'bg-orange-500', icon: Package },
-  sedang_dikerjakan: { label: 'Sedang Dikerjakan', color: 'bg-blue-500', icon: Settings },
-  selesai: { label: 'Selesai', color: 'bg-green-500', icon: CheckCircle },
-  sudah_diambil: { label: 'Sudah Diambil', color: 'bg-emerald-500', icon: CheckCircle },
-  cencel: { label: 'Cencel', color: 'bg-red-600', icon: AlertCircle },
-} as const;
+const statusConfig: Record<ServiceStatus, { label: string; color: string; icon: typeof Clock }> = {
+  pending: { label: SERVICE_STATUS_LABELS.pending, color: 'bg-yellow-500', icon: Clock },
+  checking: { label: SERVICE_STATUS_LABELS.checking, color: 'bg-yellow-500', icon: Clock },
+  'waiting-technician': { label: SERVICE_STATUS_LABELS['waiting-technician'], color: 'bg-gray-500', icon: AlertCircle },
+  'waiting-confirmation': { label: SERVICE_STATUS_LABELS['waiting-confirmation'], color: 'bg-red-500', icon: AlertCircle },
+  'waiting-parts': { label: SERVICE_STATUS_LABELS['waiting-parts'], color: 'bg-orange-500', icon: Package },
+  'in-progress': { label: SERVICE_STATUS_LABELS['in-progress'], color: 'bg-blue-500', icon: Settings },
+  testing: { label: SERVICE_STATUS_LABELS.testing, color: 'bg-indigo-500', icon: Settings },
+  completed: { label: SERVICE_STATUS_LABELS.completed, color: 'bg-green-500', icon: CheckCircle },
+  delivered: { label: SERVICE_STATUS_LABELS.delivered, color: 'bg-emerald-500', icon: CheckCircle },
+  cancelled: { label: SERVICE_STATUS_LABELS.cancelled, color: 'bg-red-600', icon: AlertCircle },
+};
 
 export default function ServiceStatus() {
   const [serviceNumber, setServiceNumber] = useState("");
@@ -78,7 +82,8 @@ export default function ServiceStatus() {
     }).format(Number(amount));
   };
 
-  const status = serviceData?.status ? statusConfig[serviceData.status as keyof typeof statusConfig] : null;
+  const normalizedStatus = normalizeServiceStatus(serviceData?.status ?? undefined);
+  const status = normalizedStatus ? statusConfig[normalizedStatus] : null;
   const StatusIcon = status?.icon || Clock;
 
   return (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2218,14 +2218,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Status-specific validation based on cancellation type  
-      if (cancellationType === 'after_completed' && existingTicket.status !== 'selesai' && existingTicket.status !== 'sudah_diambil') {
+      if (cancellationType === 'after_completed' && existingTicket.status !== 'completed' && existingTicket.status !== 'delivered') {
         return res.status(400).json({
           message: "Cannot cancel with 'after_completed' type - service ticket is not completed"
         });
       }
 
       if (cancellationType === 'warranty_refund') {
-        if (existingTicket.status !== 'selesai' && existingTicket.status !== 'sudah_diambil') {
+        if (existingTicket.status !== 'completed' && existingTicket.status !== 'delivered') {
           return res.status(400).json({
             message: "Cannot cancel with 'warranty_refund' type - service ticket must be completed or under warranty claim"
           });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -36,13 +36,16 @@ export const userRoleEnum = pgEnum('user_role', ['super_admin', 'admin', 'kasir'
 export const transactionTypeEnum = pgEnum('transaction_type', ['sale', 'service', 'purchase', 'return']);
 export const paymentMethodEnum = pgEnum('payment_method', ['cash', 'transfer', 'qris', 'installment']);
 export const serviceStatusEnum = pgEnum('service_status', [
-  'sedang_dicek',
-  'menunggu_konfirmasi',
-  'menunggu_sparepart',
-  'sedang_dikerjakan',
-  'selesai',
-  'sudah_diambil',
-  'cencel'
+  'pending',
+  'checking',
+  'in-progress',
+  'waiting-technician',
+  'testing',
+  'waiting-confirmation',
+  'waiting-parts',
+  'completed',
+  'delivered',
+  'cancelled'
 ]);
 export const stockMovementTypeEnum = pgEnum('stock_movement_type', ['in', 'out', 'adjustment']);
 export const stockReferenceTypeEnum = pgEnum('stock_reference_type', ['sale', 'service', 'purchase', 'adjustment', 'return']);
@@ -279,7 +282,7 @@ export const serviceTickets = pgTable("service_tickets", {
   actualCost: decimal("actual_cost", { precision: 12, scale: 2 }),
   laborCost: decimal("labor_cost", { precision: 12, scale: 2 }),
   partsCost: decimal("parts_cost", { precision: 12, scale: 2 }),
-  status: serviceStatusEnum("status").default('sedang_dicek'),
+  status: serviceStatusEnum("status").default('pending'),
   technicianId: varchar("technician_id").references(() => users.id),
   estimatedCompletion: timestamp("estimated_completion", { withTimezone: true }).default(sql`now()`),
   completedAt: timestamp("completed_at", { withTimezone: true }).default(sql`now()`),

--- a/shared/service-cancellation-schema.ts
+++ b/shared/service-cancellation-schema.ts
@@ -52,13 +52,13 @@ export const validateCancellationBusinessRules = {
       return { isValid: false, errors };
     }
     
-    if (ticket.status === 'cencel') {
+    if (ticket.status === 'cancelled') {
       errors.push("Service ticket sudah dibatalkan sebelumnya");
       return { isValid: false, errors };
     }
 
     // Additional business rules can be added here
-    if (ticket.status === 'sudah_diambil' && ticket.deliveredAt) {
+    if (ticket.status === 'delivered' && ticket.deliveredAt) {
       const deliveredDate = new Date(ticket.deliveredAt);
       const now = new Date();
       const daysDifference = Math.floor((now.getTime() - deliveredDate.getTime()) / (1000 * 60 * 60 * 24));

--- a/shared/service-status.ts
+++ b/shared/service-status.ts
@@ -1,0 +1,95 @@
+export const SERVICE_STATUS_VALUES = [
+  'pending',
+  'checking',
+  'in-progress',
+  'waiting-technician',
+  'testing',
+  'waiting-confirmation',
+  'waiting-parts',
+  'completed',
+  'delivered',
+  'cancelled',
+] as const;
+
+export type ServiceStatus = typeof SERVICE_STATUS_VALUES[number];
+
+export type LegacyServiceStatus =
+  | 'sedang_dicek'
+  | 'menunggu_konfirmasi'
+  | 'menunggu_sparepart'
+  | 'sedang_dikerjakan'
+  | 'selesai'
+  | 'sudah_diambil'
+  | 'cencel';
+
+export const LEGACY_STATUS_MAP: Record<LegacyServiceStatus, ServiceStatus> = {
+  sedang_dicek: 'pending',
+  menunggu_konfirmasi: 'waiting-confirmation',
+  menunggu_sparepart: 'waiting-parts',
+  sedang_dikerjakan: 'in-progress',
+  selesai: 'completed',
+  sudah_diambil: 'delivered',
+  cencel: 'cancelled',
+};
+
+const STATUS_SET = new Set<string>(SERVICE_STATUS_VALUES);
+
+export const SERVICE_STATUS_LABELS: Record<ServiceStatus, string> = {
+  pending: 'Sedang Dicek',
+  checking: 'Sedang Dicek',
+  'in-progress': 'Sedang Dikerjakan',
+  'waiting-technician': 'Ditunggu Teknisi',
+  testing: 'Testing',
+  'waiting-confirmation': 'Menunggu Konfirmasi',
+  'waiting-parts': 'Menunggu Sparepart',
+  completed: 'Selesai',
+  delivered: 'Sudah Diambil',
+  cancelled: 'Dibatalkan',
+};
+
+export const FINAL_SERVICE_STATUSES: ServiceStatus[] = ['completed', 'delivered', 'cancelled'];
+
+export function normalizeServiceStatus(value: string | null | undefined): ServiceStatus | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-');
+
+  if (STATUS_SET.has(normalized)) {
+    return normalized as ServiceStatus;
+  }
+
+  if (normalized in LEGACY_STATUS_MAP) {
+    return LEGACY_STATUS_MAP[normalized as LegacyServiceStatus];
+  }
+
+  return undefined;
+}
+
+export function coerceServiceStatus(value: string | null | undefined, fallback: ServiceStatus = 'pending'): ServiceStatus {
+  return normalizeServiceStatus(value) ?? fallback;
+}
+
+export function isFinalServiceStatus(value: string | null | undefined): boolean {
+  const status = normalizeServiceStatus(value);
+  return status ? FINAL_SERVICE_STATUSES.includes(status) : false;
+}
+
+export function getServiceStatusLabel(value: string | null | undefined, fallback = 'Status Tidak Diketahui'): string {
+  const status = normalizeServiceStatus(value);
+  return status ? SERVICE_STATUS_LABELS[status] : fallback;
+}
+
+export function mapLegacyStatusToCurrent(status: LegacyServiceStatus): ServiceStatus {
+  return LEGACY_STATUS_MAP[status];
+}
+
+export function maybeMapLegacyStatus(value: string | null | undefined): ServiceStatus | undefined {
+  const status = normalizeServiceStatus(value);
+  return status;
+}


### PR DESCRIPTION
## Summary
- add a shared service-status utility that normalizes legacy Indonesian values to the existing Postgres enum and exposes localized labels
- update schema defaults plus server filtering/cancellation/notification logic to use the English enum values while handling completed, delivered, and cancelled tickets correctly
- refresh client dashboards, ticket management, receipts, and status tracker UIs to rely on the shared status helper and display localized labels for the normalized values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e036ee4f34832693390d36acd0840d