### PR TITLE
Remove duplicate service ticket status option

### DIFF
--- a/client/src/pages/service-tickets.tsx
+++ b/client/src/pages/service-tickets.tsx
@@ -123,7 +123,6 @@ const statusColors: Record<ServiceTicketStatus, { bg: string; text: string; icon
 
 const serviceStatusOptions: { value: ServiceTicketStatus; label: string }[] = [
   'pending',
-  'checking',
   'waiting-technician',
   'waiting-confirmation',
   'waiting-parts',


### PR DESCRIPTION
## Summary
- remove the `checking` entry from the service ticket status option list so the dropdown no longer shows duplicate "Sedang Dicek"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e03d3fe204832699f459690904c729