### PR TITLE
Fix websocket URL derived from API base

### DIFF
--- a/client/src/lib/websocket.ts
+++ b/client/src/lib/websocket.ts
@@ -40,8 +40,9 @@ class WebSocketManager {
     if (envApiUrl) {
       try {
         const url = new URL(envApiUrl, window.location.href);
-        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-        return `${url.protocol}//${url.host}${url.pathname.replace(/\/$/, '')}/ws`;
+        const protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+        const host = url.host;
+        return `${protocol}//${host}/ws`;
       } catch (error) {
         console.warn('Unable to parse VITE_API_URL for websocket usage:', error);
       }


### PR DESCRIPTION
## Summary
- ensure websocket connections derived from VITE_API_URL target the server host without inheriting the API path

## Testing
- npm run check *(fails: existing TypeScript errors in admin-saas, service-tickets, and SaaS server files)*

------
https://chatgpt.com/codex/tasks/task_e_68e04381d17c832685883d1d1c8bdf01