### PR TITLE
Remove outdated sales comparison text from dashboard

### DIFF
--- a/client/src/components/dashboard/stat-card.tsx
+++ b/client/src/components/dashboard/stat-card.tsx
@@ -10,7 +10,7 @@ import {
 interface StatCardProps {
   title: string;
   value: string;
-  change: string;
+  change?: string;
   icon: string;
   color: "primary" | "accent" | "destructive" | "secondary";
   "data-testid"?: string;
@@ -43,9 +43,11 @@ export default function StatCard({ title, value, change, icon, color, ...props }
             <p className="text-2xl font-bold text-foreground" data-testid={`stat-value-${title.toLowerCase().replace(/\s+/g, '-')}`}>
               {value}
             </p>
-            <p className="text-sm text-accent mt-1">
-              {change}
-            </p>
+            {change && (
+              <p className="text-sm text-accent mt-1">
+                {change}
+              </p>
+            )}
           </div>
           <div className={`w-12 h-12 rounded-lg flex items-center justify-center ${colorMap[color]}`}>
             <IconComponent className="w-6 h-6" />

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -129,7 +129,6 @@ export default function Dashboard() {
             <StatCard
               title="Penjualan Hari Ini"
               value={statsLoading ? "Memuat..." : `Rp ${Number((stats as any)?.todaySales || 0).toLocaleString('id-ID')}`}
-              change="+12% dari kemarin"
               icon="money-bill-wave"
               color="primary"
               data-testid="stat-today-sales"

--- a/laptoppos-deployment-20250903-113337/client/src/pages/dashboard.tsx
+++ b/laptoppos-deployment-20250903-113337/client/src/pages/dashboard.tsx
@@ -50,7 +50,6 @@ export default function Dashboard() {
             <StatCard
               title="Penjualan Hari Ini"
               value={statsLoading ? "Memuat..." : `Rp ${Number(stats?.todaySales || 0).toLocaleString('id-ID')}`}
-              change="+12% dari kemarin"
               icon="money-bill-wave"
               color="primary"
               data-testid="stat-today-sales"


### PR DESCRIPTION
## Summary
- hide the sales comparison line on the daily sales stat card
- allow dashboard stat cards to omit the change text when not provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35718600c83269b58af314ca6c87d