### PR TITLE
Fix WhatsApp reconnect after manual disconnect

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2922,7 +2922,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: 'WhatsApp not enabled in settings' });
       }
 
-      await whatsappService.initialize();
+      await whatsappService.connect();
       res.json({ message: 'WhatsApp connection initiated' });
     } catch (error) {
       console.error('Error connecting WhatsApp:', error);

--- a/server/whatsappService.ts
+++ b/server/whatsappService.ts
@@ -88,6 +88,19 @@ export class WhatsAppService {
     }
   }
 
+  /**
+   * Allow manual reconnection attempts after a forceful disconnect.
+   * This resets the forceDisconnect flag and delegates to initialize().
+   */
+  async connect() {
+    if (this.forceDisconnect) {
+      console.log('Resetting forceDisconnect flag for manual reconnect request');
+      this.forceDisconnect = false;
+    }
+
+    await this.initialize();
+  }
+
 
   async sendMessage(phoneNumber: string, message: string): Promise<boolean> {
     // Enhanced connection checking
@@ -587,14 +600,12 @@ ${storeConfig?.email ? `📧 ${storeConfig.email}` : ''}`;
   async toggleWhatsApp(enable: boolean) {
     if (enable) {
       console.log("🔌 Mengaktifkan WhatsApp...");
-      this.forceDisconnect = false;
-      await this.initialize();
+      await this.connect();
     } else {
       console.log("⛔ Menonaktifkan WhatsApp...");
       await this.disconnect();
       // Setelah disconnect, langsung inisialisasi ulang untuk generate QR baru
-      this.forceDisconnect = false;
-      await this.initialize();
+      await this.connect();
     }
     // Broadcast status langsung ke frontend
     realtimeService.broadcast({


### PR DESCRIPTION
## Summary
- add a dedicated connect helper on the WhatsApp service to reset the force disconnect flag before reconnecting
- call the new helper from the WhatsApp connect route so manual reconnection works after a disconnect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35fec1f20832681509cf48d4e4375