### PR TITLE
Fix WhatsApp QR status retrieval from storage

### DIFF
--- a/server/whatsappService.ts
+++ b/server/whatsappService.ts
@@ -160,6 +160,18 @@ export class WhatsAppService {
     return this.qrCode;
   }
 
+  /**
+   * Hydrate QR code from persisted storage when service
+   * instance hasn't received a fresh QR event yet. This is
+   * useful right after a server restart where the QR is still
+   * stored in database but not in memory.
+   */
+  hydrateQRCode(qr: string | null) {
+    if (qr && !this.qrCode) {
+      this.qrCode = qr;
+    }
+  }
+
   isConnected(): boolean {
     return this.connectionState === 'open';
   }


### PR DESCRIPTION
## Summary
- load the WhatsApp QR code from persisted store configuration when the in-memory service has not yet received an updated QR
- hydrate the WhatsApp service cache with the stored QR value so repeated status calls return the code for the dashboard

## Testing
- npm run check *(fails: existing TypeScript errors in admin SaaS and service ticket pages as well as duplicate identifier issues in SaaS controllers/routes)*

------
https://chatgpt.com/codex/tasks/task_e_68e361f3c5c88326a52803eab4ee7396