### PR TITLE
Fix WebSocket path to work behind API proxy

### DIFF
--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -14,9 +14,9 @@ export class RealtimeService {
   initialize(server: Server) {
     console.log('🔄 Initializing WebSocket server for real-time updates...');
     
-    this.wss = new WebSocketServer({ 
+    this.wss = new WebSocketServer({
       server,
-      path: '/ws'
+      path: '/api/ws'
     });
 
     this.wss.on('connection', (ws: WebSocket, req) => {


### PR DESCRIPTION
## Summary
- update the realtime server to expose its WebSocket endpoint under `/api/ws` so it is routed together with the API
- normalize client-side WebSocket URL resolution to default to `/api/ws` and upgrade http(s) URLs to the correct ws(s) scheme while preserving custom overrides

## Testing
- npm run check *(fails: existing type errors in admin-saas.tsx, service-tickets.tsx, saasController.ts, admin.ts, stripe-integration.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e365a20d108326af5d2ede63db8825