### PR TITLE
Fix dashboard monthly profit to include service profit

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -44,6 +44,15 @@ export default function Dashboard() {
     retry: false,
   });
 
+  const monthlySalesProfit = Number((stats as any)?.monthlySalesProfit ?? 0);
+  const monthlyServiceProfit = Number((stats as any)?.monthlyServiceProfit ?? 0);
+  const hasDetailedProfitBreakdown =
+    (stats as any)?.monthlySalesProfit !== undefined ||
+    (stats as any)?.monthlyServiceProfit !== undefined;
+  const displayedMonthlyProfit = hasDetailedProfitBreakdown
+    ? monthlySalesProfit + monthlyServiceProfit
+    : Number((stats as any)?.monthlyProfit || 0);
+
   // Auto-refresh data setiap 5 detik untuk dashboard real-time
   useEffect(() => {
     const interval = setInterval(() => {
@@ -150,8 +159,12 @@ export default function Dashboard() {
             />
             <StatCard
               title="Profit Bulanan"
-              value={statsLoading ? "Memuat..." : `Rp ${Number((stats as any)?.monthlyProfit || 0).toLocaleString('id-ID')}`}
-              change="Harga jual - HPP"
+              value={
+                statsLoading
+                  ? "Memuat..."
+                  : `Rp ${displayedMonthlyProfit.toLocaleString('id-ID')}`
+              }
+              change="Laba penjualan + servis"
               icon="chart-line"
               color="accent"
               data-testid="stat-monthly-profit"

--- a/laptoppos-deployment-20250903-113337/server/storage.ts
+++ b/laptoppos-deployment-20250903-113337/server/storage.ts
@@ -191,9 +191,12 @@ export interface IStorage {
   // Dashboard Statistics
   getDashboardStats(): Promise<{
     todaySales: string;
+    todayRevenue: string;
     activeServices: number;
     lowStockCount: number;
     monthlyProfit: string;
+    monthlySalesProfit: string;
+    monthlyServiceProfit: string;
   }>;
 }
 
@@ -1664,6 +1667,8 @@ export class DatabaseStorage implements IStorage {
     activeServices: number;
     lowStockCount: number;
     monthlyProfit: string;
+    monthlySalesProfit: string;
+    monthlyServiceProfit: string;
   }> {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -1749,6 +1754,8 @@ export class DatabaseStorage implements IStorage {
       activeServices: activeServicesResult.count,
       lowStockCount: lowStockResult.count,
       monthlyProfit: monthlyProfit.toString(),
+      monthlySalesProfit: monthlyProfit.toString(),
+      monthlyServiceProfit: '0',
     };
   }
   

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -225,6 +225,8 @@ export interface IStorage {
     activeServices: number;
     lowStockCount: number;
     monthlyProfit: string;
+    monthlySalesProfit: string;
+    monthlyServiceProfit: string;
     whatsappConnected: boolean;
   }>;
   
@@ -2471,6 +2473,8 @@ export class DatabaseStorage implements IStorage {
     activeServices: number;
     lowStockCount: number;
     monthlyProfit: string;
+    monthlySalesProfit: string;
+    monthlyServiceProfit: string;
     whatsappConnected: boolean;
   }> {
     const clientId = this.resolveClientId();
@@ -2735,6 +2739,8 @@ export class DatabaseStorage implements IStorage {
       activeServices: activeServicesResult?.count || 0,
       lowStockCount: lowStockResult?.count || 0,
       monthlyProfit: monthlyProfit.toString(),
+      monthlySalesProfit: monthlySalesProfit.toString(),
+      monthlyServiceProfit: monthlyServiceProfit.toString(),
       whatsappConnected,
     };
   }


### PR DESCRIPTION
## Summary
- expose monthly sales and service profit values from the dashboard stats API and keep monthlyProfit as their sum
- update the dashboard monthly profit card to show the combined sales and service profit values and clarify the label

## Testing
- npm run check *(fails: existing TypeScript errors in admin-saas.tsx, service-tickets.tsx, saasController.ts, admin.ts, and stripe-integration.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e38165a8488326b1d2d792b8fb4305