### PR TITLE
Automate tenant drizzle migrations

### DIFF
--- a/docs/warranty-migration-analysis.md
+++ b/docs/warranty-migration-analysis.md
@@ -1,0 +1,34 @@
+# Analisis Pembaruan Manajemen Garansi
+
+## Ringkasan Struktur Skema Terbaru
+- Tabel `transactions` sekarang menyimpan informasi garansi seperti durasi dan tanggal mulai/berakhir untuk mendukung pengecekan masa berlaku klaim.【F:shared/schema.ts†L249-L253】
+- Tabel `service_tickets` juga memiliki kolom garansi baru agar service ticket bisa dilacak masa garansinya.【F:shared/schema.ts†L289-L292】
+- Dibuat tabel baru `warranty_claims` lengkap dengan relasi ke transaksi/service ticket asal, status proses, serta kolom catatan admin.【F:shared/schema.ts†L317-L349】
+
+## Ketergantungan Logika Aplikasi
+- Backend mengharapkan tabel `warranty_claims` tersedia untuk melakukan query, membuat klaim, dan memperbarui status. Tanpa tabel ini operasi garansi akan gagal saat melakukan `SELECT`/`INSERT`/`UPDATE`.【F:server/storage.ts†L2880-L3053】
+- Antarmuka pengguna menampilkan data garansi dari kolom baru pada transaksi dan service ticket, sehingga data tersebut harus tersedia di database untuk menghindari tampilan kosong atau error logika bisnis.【F:client/src/pages/warranty.tsx†L195-L260】
+
+## Kondisi Basis Data Saat Ini
+- Skrip basis data yang lama (`laptoppos_database.sql`) masih mendefinisikan `transactions` tanpa kolom garansi baru, sehingga instalasi yang memakai skrip ini belum memiliki struktur terbaru.【F:laptoppos_database.sql†L232-L248】
+- Struktur `service_tickets` dalam skrip lama juga belum menambahkan kolom garansi, sehingga data garansi service tidak bisa tersimpan.【F:laptoppos_database.sql†L319-L340】
+- Query backend saat ini mengharapkan kolom JSON `claimed_items` ketika membaca klaim garansi, namun kolom tersebut tidak ada pada dump SQL lama sehingga memicu error `column wc.claimed_items does not exist` seperti yang muncul di log produksi.【F:server/storage.ts†L2897-L2929】【F:laptoppos_database.sql†L1-L360】
+
+## Dampak Error Kolom `claimed_items`
+- Tanpa kolom `claimed_items`, endpoint `GET /api/warranty-claims` gagal karena select statement pada storage layer selalu merujuk ke kolom ini untuk memuat detail item yang diklaim.【F:server/storage.ts†L2897-L2929】
+- Absennya kolom tersebut juga mengakibatkan UI tidak bisa menampilkan rincian item klaim karena skema Drizzle mendefinisikannya sebagai bagian dari model `warrantyClaims`.【F:shared/schema.ts†L336-L349】
+
+## Rekomendasi Penanganan
+1. **Sinkronkan struktur database melalui workflow Drizzle** yang sudah digunakan sehari-hari:
+   - Jalankan `npx drizzle-kit push` (atau skrip `npm run db:push` yang menjadi alias resmi di repo) terhadap environment target agar definisi `jsonb("claimed_items")` dari skema Drizzle benar-benar tertulis di database.【F:package.json†L7-L12】【F:shared/schema.ts†L333-L349】
+   - Bila Anda mengandalkan folder migrasi, pastikan ada file migrasi yang menambahkan kolom `claimed_items` dan jalankan `npx drizzle-kit migrate` sampai statusnya "Nothing to migrate" sebelum mencoba ulang API.【F:drizzle.config.ts†L1-L15】
+   - Opsi manual `ALTER TABLE warranty_claims ADD COLUMN claimed_items jsonb` tetap relevan untuk patch cepat di produksi ketika tidak memungkinkan menjalankan pipeline Drizzle penuh. Jalankan perintah ini pada setiap database yang melayani tenant (termasuk tenant "utama"/default) agar seluruh instance memiliki kolom yang sama sebelum API garansi dipakai kembali.
+2. **Otomatisasikan eksekusi Drizzle untuk seluruh tenant** supaya tidak perlu lagi menjalankan perintah manual satu per satu:
+   - Gunakan skrip `npm run db:push:tenants` yang akan membaca daftar tenant dari tabel `clients`, mengekstrak `DATABASE_URL` masing-masing melalui konfigurasi `settings`, lalu menjalankan `drizzle-kit push --force` untuk setiap tenant secara berurutan. Skrip ini juga bisa diberi opsi `--migrate` atau filter `--tenant=subdomain1,subdomain2` bila perlu.【F:server/scripts/run-tenant-drizzle.ts†L1-L206】【F:package.json†L7-L13】
+   - Sertakan skrip tersebut pada pipeline provisioning tenant baru sehingga setiap tenant yang baru dibuat otomatis menjalankan migrasi garansi sebelum go-live.
+   - Untuk tenant eksisting, jalankan skrip loop sekali sehingga seluruh basis data menerima kolom `claimed_items` secara serentak, kemudian jadwalkan eksekusi rutin (mis. lewat cron/CI) bila daftar tenant bersifat dinamis.
+3. Setelah kolom tersedia, verifikasi endpoint garansi (mis. `GET /api/warranty-claims`) untuk memastikan error 500 tidak lagi muncul dan UI bisa memuat daftar klaim.
+4. Bila terdapat data klaim existing sebelum kolom baru, tentukan nilai default (misalnya `[]`) agar histori klaim tetap konsisten dan tidak memicu error parsing di frontend.
+
+## Kesimpulan & Rekomendasi
+Karena terdapat tabel baru dan kolom tambahan yang dibutuhkan oleh logika backend serta UI, instalasi yang masih memakai schema lama perlu dijalankan ulang perintah **`npm run db:push -- --force`** (atau proses migrasi sesuai environment produksi) supaya struktur database selaras dengan kode terbaru. Tanpa melakukan push ulang, manajemen garansi akan gagal berfungsi penuh (misalnya query ke `warranty_claims` akan memunculkan error tabel tidak ditemukan, dan durasi garansi tidak tersimpan di transaksi/service ticket). Setelah struktur diperbarui, lanjutkan verifikasi data existing serta backup sebelum menjalankan di lingkungan produksi.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:push:tenants": "tsx server/scripts/run-tenant-drizzle.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.17.0",

--- a/server/scripts/run-tenant-drizzle.ts
+++ b/server/scripts/run-tenant-drizzle.ts
@@ -1,0 +1,226 @@
+import 'dotenv/config';
+
+import { primaryDb, resolveTenantConnectionString, runDrizzleCli, shutdownAllDbPools } from '../db';
+import { clients } from '../../shared/saas-schema';
+
+type TenantRow = {
+  id: string;
+  name: string;
+  subdomain: string;
+  settings: string | null;
+};
+
+type CliMode = 'push' | 'migrate';
+
+const parseListArg = (value: string | undefined) => {
+  if (!value) {
+    return [] as string[];
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .map((item) => item.toLowerCase());
+};
+
+const parseSettings = (rawSettings: string | null) => {
+  if (!rawSettings) {
+    return {} as Record<string, unknown>;
+  }
+
+  try {
+    const parsed = JSON.parse(rawSettings);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+  } catch (error) {
+    console.warn('Unable to parse tenant settings JSON, falling back to empty object:', error);
+  }
+
+  return {} as Record<string, unknown>;
+};
+
+const main = async (): Promise<number> => {
+  const argv = process.argv.slice(2);
+  let mode: CliMode = 'push';
+  let forcePush = true;
+  let includePrimary = false;
+  const explicitTenants = new Set<string>();
+  const skippedTenants = new Set<string>();
+  const forwardedArgs: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--push') {
+      mode = 'push';
+      continue;
+    }
+
+    if (arg === '--migrate') {
+      mode = 'migrate';
+      forcePush = false;
+      continue;
+    }
+
+    if (arg === '--force') {
+      forcePush = true;
+      continue;
+    }
+
+    if (arg === '--no-force') {
+      forcePush = false;
+      continue;
+    }
+
+    if (arg === '--include-primary') {
+      includePrimary = true;
+      continue;
+    }
+
+    if (arg === '--tenant' || arg === '--tenants') {
+      const value = argv[index + 1];
+      index += 1;
+      for (const tenant of parseListArg(value)) {
+        explicitTenants.add(tenant);
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--tenant=')) {
+      const [, value] = arg.split('=');
+      for (const tenant of parseListArg(value)) {
+        explicitTenants.add(tenant);
+      }
+      continue;
+    }
+
+    if (arg === '--skip') {
+      const value = argv[index + 1];
+      index += 1;
+      for (const tenant of parseListArg(value)) {
+        skippedTenants.add(tenant);
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--skip=')) {
+      const [, value] = arg.split('=');
+      for (const tenant of parseListArg(value)) {
+        skippedTenants.add(tenant);
+      }
+      continue;
+    }
+
+    if (arg === '--') {
+      forwardedArgs.push(...argv.slice(index + 1));
+      break;
+    }
+
+    forwardedArgs.push(arg);
+  }
+
+  const successfulTenants: string[] = [];
+  const failedTenants: { tenant: string; error: unknown }[] = [];
+  const skipped: { tenant: string; reason: string }[] = [];
+
+  try {
+    if (includePrimary) {
+      const primaryConnection = process.env.DATABASE_URL;
+      if (!primaryConnection) {
+        console.warn('DATABASE_URL is not set. Skipping primary database push.');
+      } else {
+        console.log(`Running drizzle ${mode} for primary database...`);
+        try {
+          await runDrizzleCli(primaryConnection, mode, {
+            force: mode === 'push' ? forcePush : undefined,
+            extraArgs: forwardedArgs,
+          });
+          successfulTenants.push('primary');
+        } catch (error) {
+          failedTenants.push({ tenant: 'primary', error });
+          console.error('Primary database drizzle command failed:', error);
+        }
+      }
+    }
+
+    const tenantRows = await primaryDb
+      .select({
+        id: clients.id,
+        name: clients.name,
+        subdomain: clients.subdomain,
+        settings: clients.settings,
+      })
+      .from(clients)
+      .orderBy(clients.createdAt);
+
+    for (const tenant of tenantRows as TenantRow[]) {
+      const identifier = tenant.subdomain.toLowerCase();
+
+      if (skippedTenants.has(identifier)) {
+        skipped.push({ tenant: identifier, reason: 'Explicitly skipped via CLI argument' });
+        continue;
+      }
+
+      if (explicitTenants.size > 0 && !explicitTenants.has(identifier)) {
+        continue;
+      }
+
+      const settings = parseSettings(tenant.settings);
+      const connectionString = resolveTenantConnectionString(identifier, settings);
+
+      if (!connectionString) {
+        skipped.push({ tenant: identifier, reason: 'No tenant database connection string available' });
+        console.warn(`Skipping tenant ${identifier}: unable to resolve connection string from settings or environment.`);
+        continue;
+      }
+
+      console.log(`Running drizzle ${mode} for tenant ${identifier} (${tenant.name})...`);
+
+      try {
+        await runDrizzleCli(connectionString, mode, {
+          force: mode === 'push' ? forcePush : undefined,
+          extraArgs: forwardedArgs,
+        });
+        successfulTenants.push(identifier);
+      } catch (error) {
+        failedTenants.push({ tenant: identifier, error });
+        console.error(`Drizzle command failed for tenant ${identifier}:`, error);
+      }
+    }
+  } finally {
+    await shutdownAllDbPools();
+  }
+
+  if (successfulTenants.length > 0) {
+    console.log(`Drizzle ${mode} succeeded for tenants: ${successfulTenants.join(', ')}`);
+  }
+
+  if (skipped.length > 0) {
+    for (const entry of skipped) {
+      console.log(`Skipped tenant ${entry.tenant}: ${entry.reason}`);
+    }
+  }
+
+  if (failedTenants.length > 0) {
+    for (const failure of failedTenants) {
+      console.error(`Tenant ${failure.tenant} failed to run drizzle ${mode}.`, failure.error);
+    }
+    return 1;
+  }
+
+  return 0;
+};
+
+main()
+  .then((exitCode) => {
+    if (exitCode !== 0) {
+      process.exit(exitCode);
+    }
+  })
+  .catch((error) => {
+    console.error('Failed to execute tenant drizzle script:', error);
+    process.exit(1);
+  });
+


### PR DESCRIPTION
## Summary
- add a reusable tenant drizzle script that runs push/migrate for each client database with filtering options
- generalize drizzle CLI helpers and expose pool shutdown utilities for scripts
- document the new npm script in the warranty migration analysis and package.json

## Testing
- npm run check *(fails: pre-existing TypeScript errors in admin SaaS/service ticket pages and duplicate import declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f3b9a8cc8326b41b7bb9b969a003